### PR TITLE
Make session_id and client_id behaviour closer to real client

### DIFF
--- a/zake/fake_client.py
+++ b/zake/fake_client.py
@@ -23,6 +23,7 @@ import logging
 import sys
 import time
 import uuid
+import hashlib
 
 import six
 
@@ -150,6 +151,14 @@ class FakeClient(object):
     @property
     def session_id(self):
         return self._partial_client.session_id
+
+    @property
+    def client_id(self):
+        sess_id = self._partial_client.session_id
+        if sess_id is None:
+            return sess_id
+        fake_password = hashlib.md5(str(sess_id).encode('ascii')).digest()
+        return (sess_id, fake_password)
 
     @property
     def timeout_exception(self):

--- a/zake/fake_client.py
+++ b/zake/fake_client.py
@@ -149,7 +149,7 @@ class FakeClient(object):
             raise k_exceptions.SessionExpiredError("Expired")
 
     @property
-    def session_id(self):
+    def _session_id(self):
         return self._partial_client.session_id
 
     @property
@@ -267,7 +267,7 @@ class FakeClient(object):
 
     def restart(self):
         with self._open_close_lock:
-            before = self.session_id
+            before = self._session_id
             self.stop()
             self.start()
             return before

--- a/zake/fake_storage.py
+++ b/zake/fake_storage.py
@@ -129,7 +129,7 @@ class FakeStorage(object):
             return self.get(path)[1]
 
     def purge(self, client):
-        if not client.session_id:
+        if not client._session_id:
             return 0
         with self._client_lock:
             if client in self._clients:
@@ -140,7 +140,7 @@ class FakeStorage(object):
         with self.lock:
             for path, data in six.iteritems(self._paths):
                 if data['ephemeral'] \
-                   and data['ephemeral_owner'] == client.session_id:
+                   and data['ephemeral_owner'] == client._session_id:
                     removals.append(path)
             data_watches = []
             for path in removals:

--- a/zake/tests/test_client.py
+++ b/zake/tests/test_client.py
@@ -466,7 +466,7 @@ class TestClient(test.Test):
         with start_close(self.client) as c:
             self.assertRaises(k_exceptions.NoNodeError,
                               k_watchers.ChildrenWatch,
-                              self.client, "/b", cb)
+                              c, "/b", cb)
 
     def test_create_sequence(self):
         with start_close(self.client) as c:

--- a/zake/tests/test_client.py
+++ b/zake/tests/test_client.py
@@ -298,6 +298,14 @@ class TestClient(test.Test):
             self.assertIsNotNone(c.session_id)
         self.assertIsNone(self.client.session_id)
 
+    def test_client_id(self):
+        self.assertIsNone(self.client.client_id)
+        with start_close(self.client) as c:
+            sess_id, password = c.client_id
+            self.assertTrue(isinstance(sess_id, six.integer_types))
+            self.assertTrue(isinstance(password, six.binary_type))
+        self.assertIsNone(self.client.client_id)
+
     def test_data_watch_not_triggered(self):
         ev = Event()
         updates = []

--- a/zake/tests/test_client.py
+++ b/zake/tests/test_client.py
@@ -293,10 +293,11 @@ class TestClient(test.Test):
             self.assertFalse(txn.committed)
 
     def test_session_id(self):
-        self.assertIsNone(self.client.session_id)
+        self.assertIsNone(self.client._session_id)
         with start_close(self.client) as c:
-            self.assertIsNotNone(c.session_id)
-        self.assertIsNone(self.client.session_id)
+            self.assertIsNotNone(c._session_id)
+            self.assertTrue(isinstance(c._session_id, six.integer_types))
+        self.assertIsNone(self.client._session_id)
 
     def test_client_id(self):
         self.assertIsNone(self.client.client_id)


### PR DESCRIPTION
Hi,

In my tests I hit the issue that zake provides a session_id attribute, whereas in the real client this is exposed as client_id and _session_id. This pull request makes zake's behaviour closer to KazooClient. I used an md5 hash for the password to get a binary string that depends on the session id.

For reference, here is the behaviour of the real KazooClient:

```
>>> import kazoo
>>> from kazoo.client import KazooClient
>>>
>>> zk = KazooClient(hosts='10.0.0.8:2181')
>>> zk.start()
>>> zk.client_id
(94474422415551090, '\x01k~+\xe9\x91\xeeW\xb0\xd5l!\x0f\x8a\xde\xfc')
>>> zk._session_id
94474422415551092
>>> zk.session_id
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'KazooClient' object has no attribute 'session_id'
```
