### PR TITLE
fix include_data to return a tuple of  (children, stat)

### DIFF
--- a/zake/fake_client.py
+++ b/zake/fake_client.py
@@ -315,18 +315,13 @@ class FakeClient(object):
         if watch:
             with self._watches_lock:
                 self._child_watchers[path].append(watch)
+        children = []
+        for child_path in six.iterkeys(paths):
+            child_path = clean_path(child_path[len(path):])
+            children.append(child_path)
         if include_data:
-            children_with_data = []
-            for (child_path, data) in six.iteritems(paths):
-                child_path = clean_path(child_path[len(path):])
-                children_with_data.append((child_path, data))
-            return children_with_data
-        else:
-            children = []
-            for child_path in six.iterkeys(paths):
-                child_path = clean_path(child_path[len(path):])
-                children.append(child_path)
-            return children
+            return (children, self.storage.get(path)[1])
+        return children
 
     def get_children_async(self, path, watch=None, include_data=False):
         return utils.dispatch_async(self.handler, self.get_children, path,

--- a/zake/tests/test_client.py
+++ b/zake/tests/test_client.py
@@ -244,6 +244,19 @@ class TestClient(test.Test):
             c.ensure_path("/a/d")
             self.assertEqual(3, len(c.get_children("/a")))
 
+    def test_get_children_with_data(self):
+        with start_close(self.client) as c:
+            c.ensure_path("/a/b")
+            c.ensure_path("/a/c")
+            c.ensure_path("/a/d")
+            children, stat = c.get_children("/a", include_data=True)
+            self.assertEqual({'b', 'c', 'd'}, set(children))
+            self.assertEqual(stat.data_length, 0)
+            c.set('/a', b'bob')
+            children, stat = c.get_children("/a", include_data=True)
+            self.assertEqual({'b', 'c', 'd'}, set(children))
+            self.assertEqual(stat.data_length, 3)
+
     def test_exists(self):
         with start_close(self.client) as c:
             c.ensure_path("/a")


### PR DESCRIPTION
As mentioned here:

```
http://kazoo.readthedocs.org/en/latest/api/client.html#kazoo.client.KazooClient.get_children
```

Also, for reference, here is the test run against a real zookeeper:

```
>>> c.ensure_path("/a/b")
u'/a/b'
>>> c.ensure_path("/a/c")
u'/a/c'
>>> c.ensure_path("/a/d")
u'/a/d'
>>> children, stat = c.get_children("/a", include_data=True)
>>> children
[u'd', u'b', u'c']
>>> stat
ZnodeStat(czxid=110930, mzxid=110930, ctime=1445941998188, mtime=1445941998188, version=0, cversion=3, aversion=0, ephemeralOwner=0, dataLength=0, numChildren=3, pzxid=110933)
```
